### PR TITLE
Fix grid_tables import for yml configuration file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ theme: readthedocs
 
 markdown_extensions:
   - admonition
-  - mdx_grid_tables
+  - grid_tables
 
 pages:
   - Home: index.md


### PR DESCRIPTION
Fixed a minor bug from import grid tables on the yml configuration file
