### PR TITLE
Updated Docs Build link on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PowERP documentation
 
-[Build of our documentation](http://builds.gisce.net/powerp-docs/)
+[Build of our documentation](http://builds.gisce.net/powerp-docs/master/)
 
 ## Setting up your environment
 


### PR DESCRIPTION
Updated "Build to our documentation" Link, now using:

`http://builds.gisce.net/powerp-docs/master/`

Nginx should redirect to the correct lang, so the landing page is used only on testing branch's builds