### PR TITLE
Fix merge and requirements

### DIFF
--- a/check_strings.py
+++ b/check_strings.py
@@ -21,6 +21,7 @@ args = parser.parse_args()
 green = "\033[0;32m"
 yellow = "\033[0;33m"
 red = "\033[0;31m"
+purple = "\033[0;35m"
 endcl = "\033[0m"
 
 cwd = os.getcwd()
@@ -112,7 +113,7 @@ print ('(No Fuzzy)\t{}Untranslated strings:\t{}{}\t({}%)'.format(
     (len(failed_strings)-len(fuzz_strings))/lenstr * 100
 ))
 print ('\t\t{}Missing strings:\t{}{}\t({}%)'.format(
-    red, len(substr), endcl, len(substr)/lenstr * 100
+    purple, len(substr), endcl, len(substr)/lenstr * 100
 ))
 
 print ('\t----------------------------------------------------')

--- a/merge.sh
+++ b/merge.sh
@@ -8,6 +8,7 @@ echo "Reset po file from local branch"
 git reset HEAD locales/es_ES/LC_MESSAGES/messages.po
 git checkout -- locales/es_ES/LC_MESSAGES/messages.po
 echo "Merging from master"
+git fetch
 git merge origin/master
 echo "Merging pofile using msgcat"
 msgcat --use-first messages.local.po messages.remote.po -o messages.merge.po

--- a/merge.sh
+++ b/merge.sh
@@ -15,6 +15,8 @@ mv messages.merge.po locales/es_ES/LC_MESSAGES/messages.po
 echo "Cleaning repository"
 rm messages.local.po
 rm messages.remote.po
+echo "Updating python versions"
+pip install -r requirements.txt
 echo "Updating pot file to check strings after merge..."
 if [ -f locales/messages.pot ];
 then

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 mkdocs
-Markdown==2.6.7
-markdown-blockdiag
+markdown-blockdiag>=0.3.0
 markdown-i18n>=2.1.1
 # Due no pypi package: https://github.com/smartboyathome/Markdown-GridTables/issues/2
 https://github.com/mihkels/Markdown-GridTables/archive/master.zip
-
+# Ensure Markdown Version as last requirement
+Markdown==2.6.7


### PR DESCRIPTION
After a later upgrade to master, some changes have to be made locally...

- Updated _merge.sh_ to use `git fetch` before merge with `origin/master`
- Updated _merge.sh_ to use `pip install -r requirements` after merge with `origin/master`
- Updated _requirements.txt_ to match `markdown-blockdiag` version and ensure `Markdown` version
- Updated _check_strings.py_ color of the test briefing's _Missing Strings_ 