### PR TITLE
Move 'timeout' field to the correct positioning

### DIFF
--- a/docs/distri/tpl/intercambio_tpl.md
+++ b/docs/distri/tpl/intercambio_tpl.md
@@ -48,10 +48,6 @@ amb el caràcter ':', en aquest ordre:
   legals són: _“even”, “none”, “odd”, “mark”, “space”_.
 - **_stop_bits_**: bits de parada. És una cadena de caràcters i els possibles
   valors legals són: _“0”, “1”, “1.5”, “2”_.
-- **_timeout_**: temps d'espera. És un enter. Es tracta del valor límit,
-  en mil·lisegons, que GISCE-TPL esperarà a que el comptador respongui abans
-  de considerar que no es pot establir la connexió. Un valor típic i
-  raonable és _2000_, que correspon a 2000ms, és a dir, 2 segons.
 - **_direccion_de_enlace_**: Un enter.
 - **_direccion_del_punto_de_medida_**: Un enter.
 - **_contraseña_**: Un enter.
@@ -62,6 +58,10 @@ amb el caràcter ':', en aquest ordre:
     - Dades agregades cada 60 minuts, amb valors incrementals.
     - Dades agregades cada 15 minuts, amb valors absoluts.
     - Dades agregades cada 15 minuts, amb valors incrementals.
+- **_timeout_**: temps d'espera. És un enter. Es tracta del valor límit,
+  en mil·lisegons, que GISCE-TPL esperarà a que el comptador respongui abans
+  de considerar que no es pot establir la connexió. Un valor típic i
+  raonable és _2000_, que correspon a 2000ms, és a dir, 2 segons.
 
 Com es pot veure:
 

--- a/docs/distri/tpl/intercambio_tpl.md
+++ b/docs/distri/tpl/intercambio_tpl.md
@@ -51,6 +51,10 @@ amb el caràcter ':', en aquest ordre:
 - **_direccion_de_enlace_**: Un enter.
 - **_direccion_del_punto_de_medida_**: Un enter.
 - **_contraseña_**: Un enter.
+- **_timeout_**: temps d'espera. És un enter. Es tracta del valor límit,
+  en mil·lisegons, que GISCE-TPL esperarà a que el comptador respongui abans
+  de considerar que no es pot establir la connexió. Un valor típic i
+  raonable és _2000_, que correspon a 2000ms, és a dir, 2 segons.
 - **_tipo_de_curva_**: _Per sel·leccionar el tipus de corba que es desitja
   decarregar en l'apartat "Configuración" es pot sel·leccionar la corba a
   descarregar_:
@@ -58,10 +62,6 @@ amb el caràcter ':', en aquest ordre:
     - Dades agregades cada 60 minuts, amb valors incrementals.
     - Dades agregades cada 15 minuts, amb valors absoluts.
     - Dades agregades cada 15 minuts, amb valors incrementals.
-- **_timeout_**: temps d'espera. És un enter. Es tracta del valor límit,
-  en mil·lisegons, que GISCE-TPL esperarà a que el comptador respongui abans
-  de considerar que no es pot establir la connexió. Un valor típic i
-  raonable és _2000_, que correspon a 2000ms, és a dir, 2 segons.
 
 Com es pot veure:
 


### PR DESCRIPTION
- Manual TPL / 7.3 Configuracio del camp "configuracion puerto"

From:

- **_stop_bits_**
- **_timeout_**
- **_direccion_de_enlace_**

To: 

- **_contraseña_**
- **_timeout_**
- **_tipo_de_curva_**