### PR TITLE
Add inline_graphviz extension to generate graphviz

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ theme: readthedocs
 markdown_extensions:
   - admonition
   - grid_tables
+  - inline_graphviz
   - markdown_blockdiag:
       fontpath: fonts/DejaVuSans.ttf
 

--- a/mkdocs_es.yml
+++ b/mkdocs_es.yml
@@ -9,6 +9,7 @@ theme: readthedocs
 markdown_extensions:
   - admonition
   - grid_tables
+  - inline_graphviz
   - markdown_i18n:
       i18n_lang:  es_ES
       i18n_dir:   locales

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ markdown-i18n>=2.1.1
 # Due no pypi package: https://github.com/smartboyathome/Markdown-GridTables/issues/2
 https://github.com/mihkels/Markdown-GridTables/archive/master.zip
 Markdown
+markdown-inline-graphviz


### PR DESCRIPTION
Allow to use graphviz in the docs adding [sprin/markdown-inline-graphviz](https://github.com/sprin/markdown-inline-graphviz) extension