### PR TITLE
Remove mkdocs requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-mkdocs
 mkdocs-material
 markdown-blockdiag>=0.3.0
 markdown-i18n>=2.1.1


### PR DESCRIPTION
### Description:

Mkdocs requirement does install an upgraded version and material theme cannot be built.
This is due to mkdocs updating it's version before mkdocs-material theme is updated.
To prevent this situation, we remove the requirement as it'll be installed as material's theme dependency with the latest compatible version.

### Tasks:

- [x] Remove mkdocs from requirement.txt

### Links:

> No docs added...
