### PR TITLE
Fixes on the "estados de la póliza" page

### DIFF
--- a/locales/es_ES/LC_MESSAGES/messages.po
+++ b/locales/es_ES/LC_MESSAGES/messages.po
@@ -3556,7 +3556,7 @@ msgid ""
 "explicació més detallada d'aquestes, consultar\n"
 "\n"
 "<a href=\"#modificacions-contractuals_1\">aquesta</a> pàgina."
-msgstr "Desde Activa también se pueden hacer <strong>Modificaciones Contractuales</strong>. Para una explicación más detallada de éstas, consultar <a href=\"../#modificaciones-contractuales_1\">esta</a> página."
+msgstr "Desde Activa también se pueden hacer <strong>Modificaciones Contractuales</strong>. Para una explicación más detallada de éstas, consultar <a href=\"#modificaciones-contractuales_1\">esta</a> página."
 
 msgid ""
 "També es podrà donar de <strong>Baixa</strong> una pòlissa o \n"

--- a/locales/es_ES/LC_MESSAGES/messages.po
+++ b/locales/es_ES/LC_MESSAGES/messages.po
@@ -3511,7 +3511,7 @@ msgid ""
 "\n"
 "<em>Fluxograma dels estat de les pòlisses i les transicions</em>"
 msgstr ""
-"<img alt=\"Descripció dels \\label{workflows}\" src=\"../_static/polizas/workflow_ES.svg\" />\n"
+"<img alt=\"Descripció dels \\label{workflows}\" src=\"../_static/polizas/workflows_ES.svg\" />\n"
 "\n"
 "<em>Flujograma de los estados de las pólizas y sus transiciones</em>"
 


### PR DESCRIPTION
### Description:

Various fixes to the "Estados de la póliza" page in Spanish.

### Tasks:

- [x] Fixed wrong link to file name that caused the workflow diagram could not be seen in Spanish. 
- [x] Wrong link to "modificaciones contractuales" page. 

### Links:

* [es/base/polizas/#estado-de-las-polizas](http://builds.gisce.net/powerp-docs/powerp_fix_wrong_image_name/es/base/polizas/#estado-de-las-polizas)
