### PR TITLE
Add note to indicate that must fill tension on embarrat AT

### DIFF
--- a/docs/distri/adm-pub/resoluciones/circular_4-2015.md
+++ b/docs/distri/adm-pub/resoluciones/circular_4-2015.md
@@ -287,7 +287,9 @@ Per les **línies de BT** s'inclouràn les que compleixin el següent:
 Les dades referents a **l'alta tensió** estàn formades pels següents camps:
 
 !!! Info "Nota"
-    Degut a que no hi poden haver nodes iguals amb tensions diferents per tal de saber la tensió d'un node fa falta que tots els trams AT adjacents a un transformador reductor tinguin posada la tensió del tram. 
+    Degut a que no hi poden haver nodes iguals amb tensions diferents per tal 
+    de saber la tensió d'un node fa falta que tots els trams AT adjacents a un 
+    transformador reductor tinguin posada la tensió del tram. 
 
 Camp                             | Descripció
 :--------------------------------|:----------------------------------------------

--- a/docs/distri/adm-pub/resoluciones/circular_4-2015.md
+++ b/docs/distri/adm-pub/resoluciones/circular_4-2015.md
@@ -286,6 +286,9 @@ Per les **línies de BT** s'inclouràn les que compleixin el següent:
 
 Les dades referents a **l'alta tensió** estàn formades pels següents camps:
 
+!!! Info "Nota"
+    Degut a que no hi poden haver nodes iguals amb tensions diferents per tal de saber la tensio d'un node fa falta que tots els trams AT adjacents a un transformador reductor tinguin posada la tensio del tram. 
+
 Camp                             | Descripció
 :--------------------------------|:----------------------------------------------
 Tram                             | Codi del tram

--- a/docs/distri/adm-pub/resoluciones/circular_4-2015.md
+++ b/docs/distri/adm-pub/resoluciones/circular_4-2015.md
@@ -287,7 +287,7 @@ Per les **línies de BT** s'inclouràn les que compleixin el següent:
 Les dades referents a **l'alta tensió** estàn formades pels següents camps:
 
 !!! Info "Nota"
-    Degut a que no hi poden haver nodes iguals amb tensions diferents per tal de saber la tensio d'un node fa falta que tots els trams AT adjacents a un transformador reductor tinguin posada la tensio del tram. 
+    Degut a que no hi poden haver nodes iguals amb tensions diferents per tal de saber la tensió d'un node fa falta que tots els trams AT adjacents a un transformador reductor tinguin posada la tensió del tram. 
 
 Camp                             | Descripció
 :--------------------------------|:----------------------------------------------


### PR DESCRIPTION
### Description:

Add note to indicate that the tram AT adjecent to reductor transformer must have voltage set

### Tasks:

- [x] Add note

### Links:

* [F10 castella](http://builds.gisce.net/powerp-docs/powerp_update_4_2015_f10/es/distri/adm-pub/resoluciones/circular_4-2015/#f10-informacion-relativa-a-las-lineas-de-at-y-bt-alta-y-baja-tension)
* [F10 catala](http://builds.gisce.net/powerp-docs/powerp_update_4_2015_f10/ca/distri/adm-pub/resoluciones/circular_4-2015/#f10-informacio-relativa-a-les-linies-dat-i-bt-alta-i-baixa-tensio)
