### PR TITLE
ADD python3 Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: python
 python:
   - "2.7"
+  - "3.6"
 install:
   - "pip install -r requirements.txt"
 script:


### PR DESCRIPTION
### Description:

ADD Python 3.6 to Travis file to test docs build with py3

### Tasks:

- [x] ADD Py3 testing

### Links:

N/A
