### PR TITLE
IMP Material Header colour

### DIFF
--- a/docs/extra/css/site.css
+++ b/docs/extra/css/site.css
@@ -1,0 +1,3 @@
+[data-md-color-primary=indigo] .md-header, [data-md-color-primary=indigo] .md-tabs{
+    background-color: #4D77A4;
+}

--- a/docs/extra/css/site.css
+++ b/docs/extra/css/site.css
@@ -1,4 +1,4 @@
-[data-md-color-primary=indigo] .md-header
+[data-md-color-primary=indigo] .md-header, .md-header
 {
     background-color: #4D77A4;
 }
@@ -6,4 +6,29 @@
 [data-md-color-primary=indigo] .md-tabs
 {
     background-color: #436491;
+}
+
+@media only screen and (max-width: 76.1875em){
+    html [data-md-color-primary=indigo] .md-nav--primary .md-nav__title--site{
+        background-color: #4D77A4;
+    }
+    [data-md-color-primary=indigo] .md-header, .md-header
+    {
+        background-color: #4D77A4;
+    }
+
+    [data-md-color-primary=indigo] .md-nav__source
+    {
+        background-color: #436491;
+    }
+
+    html .md-nav--primary .md-nav__title
+    {
+        background-color: #436491;
+        color:white;
+    }
+    html .md-nav--primary .md-nav__title:before
+    {
+        color:white;
+    }
 }

--- a/docs/extra/css/site.css
+++ b/docs/extra/css/site.css
@@ -1,3 +1,9 @@
-[data-md-color-primary=indigo] .md-header, [data-md-color-primary=indigo] .md-tabs{
+[data-md-color-primary=indigo] .md-header
+{
     background-color: #4D77A4;
+}
+
+[data-md-color-primary=indigo] .md-tabs
+{
+    background-color: #436491;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ extra:
 
 extra_css:
   - extra/css/images.css
+  - extra/css/site.css
 
 pages:
   - Home: index.md


### PR DESCRIPTION
### Description:

Closes #262 

ADD Gisce Colour (#4D77A4) to the Tabs header

### Tasks:

- [x] Add new "site.css" file to change the header's css

### Links:

N/A - Any page

#### Before

![image](https://user-images.githubusercontent.com/19925414/40299133-91adde6a-5ce5-11e8-91cf-e3e461bad6cb.png)

#### After

![image](https://user-images.githubusercontent.com/19925414/40299347-43a818a6-5ce6-11e8-8d5c-f3d32637c59b.png)

