### PR TITLE
ADD custom footer block with build time

### DIFF
--- a/custom/main.html
+++ b/custom/main.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block footer %}
+{% include "partials/footer.html" %}
+<script>
+// Get all afected elements (copyright)
+var elements = document.getElementsByClassName("md-footer-copyright")
+var locale = navigator.language || navigator.languages[0] || "en"
+for(footer_idx=0; footer_idx< elements.length; footer_idx++){
+  var footer = elements[footer_idx]
+  footer_date=document.createElement("div")
+  // <OFFSET>minutes * 60 seconds * 1000 miliseconds * -1 local time
+  offset=new Date().getTimezoneOffset()*60*1000*-1
+  build_date=new Date("{{ build_date_utc }}").getTime()
+  build_date=new Date(build_date+offset)
+  if (locale == 'es' || locale == 'es_ES'){
+    build_text = 'Fecha última modificación: '
+  } else if (locale == 'ca' || locale == 'ca_ES') {
+    build_text = "Data d'última modificació: "
+  } else {
+    build_text = "Last build on: "
+  }
+  footer_date.innerHTML=build_text + build_date.getFullYear() + "-" + (build_date.getMonth()+1) + "-" + build_date.getDate() + " " + build_date.toLocaleTimeString(locale, {hourCycle:"h24", hour: "2-digit", minute: "2-digit",second: "2-digit"})
+  footer.appendChild(footer_date)
+}
+</script>
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ theme:
   feature:
     tabs: true
   language: 'ca'
+  custom_dir: custom
 
 markdown_extensions:
   - admonition

--- a/mkdocs_es.yml
+++ b/mkdocs_es.yml
@@ -15,6 +15,7 @@ theme:
   feature:
     tabs: true
   language: 'es'
+  custom_dir: custom
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
### Description:

Closes #67
Includes the build date of the docs on the footer using mkdocs's template build context variable `build_date_utc`

### Tasks:

- [x] Add custom Footer block using inherited block and extend the copyright section with the build date

### Links:

N/A -- ANY (See the footer section)