### PR TITLE
Stop execution if build fails on translate

### DIFF
--- a/translate.sh
+++ b/translate.sh
@@ -5,7 +5,7 @@ if [ -f locales/messages.pot ]; then
     rm locales/messages.pot
 fi
 echo "Building docs to get new pot file..."
-mkdocs build -f mkdocs_es.yml --clean
+mkdocs build -f mkdocs_es.yml --clean || echo "Failed to build, check mkdocs build!" && exit -1
 echo "Merging pofiles..."
 msgmerge -U locales/es_ES/LC_MESSAGES/messages.po locales/messages.pot
 echo "Opening updated pofile with poedit..."


### PR DESCRIPTION
### Description:

Makes "`translate.sh`" fail if the "`mkdocs build`" command fails.

### Tasks:

- [x] Add an "or" for the mkdocs build execution, halting the script execution

### Links:

N/A